### PR TITLE
Implement list API to read all products

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -123,6 +123,19 @@ def delete_products(product_id):
     return jsonify(message="success"), status.HTTP_204_NO_CONTENT
 
 ######################################################################
+# LIST ALL PRODUCTS
+######################################################################
+
+@app.route("/products", methods=["GET"])
+def list_products():
+    """
+    Lists all products.
+    This endpoint will list all the products.
+    """
+    app.logger.info("Request to list all products")
+    pass
+
+######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -132,8 +132,12 @@ def list_products():
     Lists all products.
     This endpoint will list all the products.
     """
-    app.logger.info("Request to list all products")
-    pass
+    app.logger.info("Request to list all products.")
+    products = Product.all()
+    results = [product.serialize() for product in products]
+    app.logger.info(f"Returning {len(results)} products.")
+    response = jsonify(results), status.HTTP_200_OK
+    return response
 
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -235,7 +235,6 @@ class TestProductsServer(TestCase):
         for _ in range(N):
             response = self.client.delete(f"{BASE_URL}/{test_product.id}")
             self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-<<<<<<< HEAD
 
     def test_method_not_allowed(self):
         """It should not allow an illegal method call"""
@@ -244,7 +243,6 @@ class TestProductsServer(TestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         data = response.get_json()
         logging.debug("Response data = %s", data)
-=======
     
     def test_list_products(self):
         """This should list all products"""
@@ -252,4 +250,3 @@ class TestProductsServer(TestCase):
         response = self.client.get(BASE_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.get_json()), len(products))
->>>>>>> e42b49d (Add UT for list products API)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -235,6 +235,7 @@ class TestProductsServer(TestCase):
         for _ in range(N):
             response = self.client.delete(f"{BASE_URL}/{test_product.id}")
             self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+<<<<<<< HEAD
 
     def test_method_not_allowed(self):
         """It should not allow an illegal method call"""
@@ -243,3 +244,12 @@ class TestProductsServer(TestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         data = response.get_json()
         logging.debug("Response data = %s", data)
+=======
+    
+    def test_list_products(self):
+        """This should list all products"""
+        products = self._create_products()
+        response = self.client.get(BASE_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.get_json()), len(products))
+>>>>>>> e42b49d (Add UT for list products API)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -235,14 +235,6 @@ class TestProductsServer(TestCase):
         for _ in range(N):
             response = self.client.delete(f"{BASE_URL}/{test_product.id}")
             self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-
-    def test_method_not_allowed(self):
-        """It should not allow an illegal method call"""
-        # test_product = ProductFactory()
-        response = self.client.get(BASE_URL)
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        data = response.get_json()
-        logging.debug("Response data = %s", data)
     
     def test_list_products(self):
         """This should list all products"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -246,7 +246,7 @@ class TestProductsServer(TestCase):
     
     def test_list_products(self):
         """This should list all products"""
-        products = self._create_products()
+        products = self._create_products(5)
         response = self.client.get(BASE_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.get_json()), len(products))


### PR DESCRIPTION
* This PR closes #14. 
* We implement the API endpoint to list all products.
* We have corresponding tests implemented as well.
* The code coverage in the end is 95% and also all the tests pass.

Updates:
* Merge with master for recent changes.
* Remove `test_method_not_allowed` because we now have `list` API that exposes the base url as endpoint.