### PR TITLE
Implement filtering in List API

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -133,7 +133,21 @@ def list_products():
     This endpoint will list all the products.
     """
     app.logger.info("Request to list all products.")
-    products = Product.all()
+    
+    products = []
+    name = request.args.get("name")
+    category = request.args.get("category")
+    price = request.args.get("price")
+
+    if name:
+        products = Product.find_by_name(name)
+    elif category:
+        products = Product.find_by_category(category)
+    elif price:
+        products = Product.find_by_price(price)
+    else:
+        products = Product.all()
+
     results = [product.serialize() for product in products]
     app.logger.info(f"Returning {len(results)} products.")
     response = jsonify(results), status.HTTP_200_OK

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -256,7 +256,7 @@ class TestProductsServer(TestCase):
             self.assertEqual(product["name"], name)
     
     def test_list_products_with_category(self):
-        """List all the products with a particular name"""
+        """List all the products with a particular category"""
         products = self._create_products(5)
         category = products[0].category
         count = len([product for product in products if product.category == category])

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -242,3 +242,16 @@ class TestProductsServer(TestCase):
         response = self.client.get(BASE_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.get_json()), len(products))
+    
+    def test_list_products_with_name(self):
+        """List all the products with a particular name"""
+        products = self._create_products(5)
+        name = products[0].name
+        count = len([product for product in products if product.name == name])
+        response = self.client.get(f"{BASE_URL}?name={name}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.get_json()
+        self.assertEqual(len(response_data), count)
+        for product in response_data:
+            self.assertEqual(product["name"], name)
+

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -254,4 +254,16 @@ class TestProductsServer(TestCase):
         self.assertEqual(len(response_data), count)
         for product in response_data:
             self.assertEqual(product["name"], name)
+    
+    def test_list_products_with_category(self):
+        """List all the products with a particular name"""
+        products = self._create_products(5)
+        category = products[0].category
+        count = len([product for product in products if product.category == category])
+        response = self.client.get(f"{BASE_URL}?category={category}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.get_json()
+        self.assertEqual(len(response_data), count)
+        for product in response_data:
+            self.assertEqual(product["category"], category)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -267,3 +267,15 @@ class TestProductsServer(TestCase):
         for product in response_data:
             self.assertEqual(product["category"], category)
 
+    def test_list_products_with_price(self):
+            """List all the products with a particular price"""
+            products = self._create_products(5)
+            price = products[0].price
+            count = len([product for product in products if product.price == price])
+            response = self.client.get(f"{BASE_URL}?price={price}")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response_data = response.get_json()
+            self.assertEqual(len(response_data), count)
+            for product in response_data:
+                self.assertEqual(product["price"], price)
+


### PR DESCRIPTION
* This PR closes #14.
* In the earlier PR #26 , we didn't implement filtering.
* We add filtering based on name, category and price.
* The corresponding tests pass and we have the same code coverage.