### PR TITLE
Add a project API key to the Products dev container

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     container_name: project
     volumes:
       - ..:/app
-      - ~/.bluemix/project_apikey.json:/home/vscode/apikey.json
+
     command: sleep infinity
     environment:
       FLASK_APP: service:app

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,8 +16,7 @@ services:
     environment:
       FLASK_APP: service:app
       FLASK_DEBUG: "True"
-      # PORT: 8000
-      
+      PORT: 8000
       GUNICORN_BIND: "0.0.0.0:8080"
       DATABASE_URI: postgresql://postgres:postgres@postgres:5432/postgres
     networks:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,8 @@ services:
     container_name: project
     volumes:
       - ..:/app
-      - ~/.bluemix/apikey-team.json:/home/vscode/apikey-team.json
+      # - ~/.bluemix/apikey-team.json:/home/vscode/apikey-team.json
+      - ~/.bluemix/project_apikey.json:/home/vscode/apikey.json
     command: sleep infinity
     environment:
       FLASK_APP: service:app

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       FLASK_APP: service:app
       FLASK_DEBUG: "True"
-      PORT: 8000
+      # PORT: 8000
       GUNICORN_BIND: "0.0.0.0:8080"
       DATABASE_URI: postgresql://postgres:postgres@postgres:5432/postgres
     networks:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     container_name: project
     volumes:
       - ..:/app
-
+      - ~/.bluemix/project_apikey.json:/home/vscode/apikey.json
     command: sleep infinity
     environment:
       FLASK_APP: service:app

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,13 +11,13 @@ services:
     container_name: project
     volumes:
       - ..:/app
-      # - ~/.bluemix/apikey-team.json:/home/vscode/apikey-team.json
       - ~/.bluemix/project_apikey.json:/home/vscode/apikey.json
     command: sleep infinity
     environment:
       FLASK_APP: service:app
       FLASK_DEBUG: "True"
       # PORT: 8000
+      
       GUNICORN_BIND: "0.0.0.0:8080"
       DATABASE_URI: postgresql://postgres:postgres@postgres:5432/postgres
     networks:


### PR DESCRIPTION
- Generate a shared Products API Key from IBM Cloud
- Download and rename it `project_apikey.json` and move it to `~/.bluemix` folder
- Edit `.devcontainer/docker-compose.yaml` file to add the project API key